### PR TITLE
rpc: update estimatesmartfee

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1097,6 +1097,8 @@ static RPCHelpMan estimatesmartfee()
     RPCTypeCheckArgument(request.params[0], UniValue::VNUM);
 
     CBlockPolicyEstimator& fee_estimator = EnsureAnyFeeEstimator(request.context);
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    const CTxMemPool& mempool = EnsureMemPool(node);
 
     unsigned int max_target = fee_estimator.HighestTargetTracked(FeeEstimateHorizon::LONG_HALFLIFE);
     unsigned int conf_target = ParseConfirmTarget(request.params[0], max_target);
@@ -1113,6 +1115,14 @@ static RPCHelpMan estimatesmartfee()
     UniValue errors(UniValue::VARR);
     FeeCalculation feeCalc;
     CFeeRate feeRate = fee_estimator.estimateSmartFee(conf_target, &feeCalc, conservative);
+    CFeeRate min_mempool_feerate = mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
+    if (feeRate < min_mempool_feerate) {
+        feeRate = min_mempool_feerate;
+    }
+    CFeeRate min_relay_feerate = ::minRelayTxFee;
+    if (feeRate < min_relay_feerate) {
+        feeRate = min_relay_feerate;
+    }
     if (feeRate != CFeeRate(0)) {
         result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
     } else {

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -133,9 +133,13 @@ def check_smart_estimates(node, fees_seen):
     delta = 1.0e-6  # account for rounding error
     last_feerate = float(max(fees_seen))
     all_smart_estimates = [node.estimatesmartfee(i) for i in range(1, 26)]
+    mempoolMinFee = node.getmempoolinfo()['mempoolminfee']
+    minRelaytxFee = node.getmempoolinfo()['minrelaytxfee']
     for i, e in enumerate(all_smart_estimates):  # estimate is for i+1
         feerate = float(e["feerate"])
         assert_greater_than(feerate, 0)
+        assert_greater_than_or_equal(feerate,float(mempoolMinFee))
+        assert_greater_than_or_equal(feerate,float(minRelaytxFee))
 
         if feerate + delta < min(fees_seen) or feerate - delta > max(fees_seen):
             raise AssertionError("Estimated fee (%f) out of range (%f,%f)"
@@ -276,6 +280,11 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         self.sync_blocks(self.nodes[0:3], wait=.1)
         self.log.info("Final estimates after emptying mempools")
+        check_estimates(self.nodes[1], self.fees_per_kb)
+
+        # check that the effective feerate is greater than or equal to the mempoolminfee even for high mempoolminfee
+        self.log.info("Estimates after restarting node with high MempoolMinFee")
+        self.restart_node(1, extra_args=['-minrelaytxfee=0.0003'])
         check_estimates(self.nodes[1], self.fees_per_kb)
 
         self.log.info("Testing that fee estimation is disabled in blocksonly.")


### PR DESCRIPTION
This PR is in response to the issue [#19699](https://github.com/bitcoin/bitcoin/issues/19699).

Based on the discussion in the comments of PR [#22673](https://github.com/bitcoin/bitcoin/pull/22673) changes have been made in the `estimatesmartfee` itself such that it accounts for `mempoolMinFee` and `relayMinFee` . Hence it provides a fee estimate that is most likely to be paid by the user in an actual transaction, preventing issues such as [#16072](https://github.com/bitcoin/bitcoin/issues/16072).

The test file test/functional/feature_fee_estimation.py has also been updated to check this functionality.